### PR TITLE
Can create a Megaphone Podcast Episode record from Episode class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://circleci.com/gh/SCPR/megaphone_client.png)](https://circleci.com/gh/SCPR/megaphone_client)
+
 # Megaphone Client
 Unofficial Ruby client for the Megaphone API
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ megaphone.podcasts.list
 ### Creating
 
 ```ruby
-megaphone.episode.create({
+megaphone.episodes.create({
   podcast_id: '{podcast_id}',
   body: {
     title: "{episode title}",

--- a/README.md
+++ b/README.md
@@ -52,9 +52,14 @@ megaphone.podcasts.list
 
 ### Creating
 
-**(TO:DO)**
 ```ruby
-megaphone.episodes.create(attributes)
+megaphone.episode.create({
+  podcast_id: '{podcast_id}',
+  body: {
+    title: "{episode title}",
+    pubdate: "2020-06-01T14:54:02.690Z"
+  }
+})
 ```
 
 ## Tests
@@ -71,4 +76,6 @@ http://www.rubydoc.info/github/SCPR/megaphone_client/master/
 
 ## Contributing
 
-Pull Requests are encouraged!
+Pull Requests are encouraged! Suggested practice:
+- Fork and make changes
+- Submit a PR from fork to this master

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -3,9 +3,6 @@ require "megaphone_client/episode"
 
 # @author Jay Arella
 module MegaphoneClient
-  class ClientError < StandardError
-  end
-
   class ConnectionError < StandardError
   end
 

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -3,6 +3,9 @@ require "megaphone_client/episode"
 
 # @author Jay Arella
 module MegaphoneClient
+  class ClientError < StandardError
+  end
+
   class ConnectionError < StandardError
   end
 

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -32,7 +32,7 @@ module MegaphoneClient
 
       def create options={}
         if !options[:podcast_id] || !options[:body] || !options[:body][:title] || !options[:body][:pubdate]
-          raise MegaphoneClient::ConnectionError.new("podcast_id, body.title, and body.pubdate options are required.")
+          raise MegaphoneClient::ClientError.new("podcast_id, body.title, and body.pubdate options are required.")
         end
 
         MegaphoneClient.connection({
@@ -79,7 +79,7 @@ module MegaphoneClient
 
       def update options={}
         if !options[:podcast_id] || !options[:episode_id]
-          raise MegaphoneClient::ConnectionError.new("Both podcast_id and episode_id options are required.")
+          raise MegaphoneClient::ClientError.new("Both podcast_id and episode_id options are required.")
         end
 
         MegaphoneClient.connection({

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -18,15 +18,17 @@ module MegaphoneClient
       end
 
       # @return a struct that represents the episode that was created
-      # @note If a :podcast_id, :title, and :pubdate aren't given, it raises an error.
+      # @note If a :podcast_id, :body[:title], and :body[:pubdate] aren't given, it raises an error.
       # @see MegaphoneClient#connection
       # @example Create an episode
-      #   megaphone.episode.update({
+      #   megaphone.episode.create({
       #     podcast_id: '12345',
-      #     episode_id: '56789',
-      #     body: { preCount: 2 }
+      #     body: {
+      #       title: "title",
+      #       pubdate: "2020-06-01T14:54:02.690Z"
+      #     }
       #   })
-      #   #=> A struct representing episode '56789' with preCount 2
+      #   #=> A struct representing episode '12345' with title, "title", and scheduled to publish at June 1st, 2020
 
       def create options={}
         if !options[:podcast_id] || !options[:body] || !options[:body][:title] || !options[:body][:pubdate]

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -17,6 +17,29 @@ module MegaphoneClient
         @config ||= MegaphoneClient
       end
 
+      # @return a struct that represents the episode that was created
+      # @note If a :podcast_id, :title, and :pubdate aren't given, it raises an error.
+      # @see MegaphoneClient#connection
+      # @example Create an episode
+      #   megaphone.episode.update({
+      #     podcast_id: '12345',
+      #     episode_id: '56789',
+      #     body: { preCount: 2 }
+      #   })
+      #   #=> A struct representing episode '56789' with preCount 2
+
+      def create options={}
+        if !options[:podcast_id] || !options[:body] || !options[:body][:title] || !options[:body][:pubdate]
+          raise MegaphoneClient::ConnectionError.new("podcast_id, body.title, and body.pubdate options are required.")
+        end
+
+        MegaphoneClient.connection({
+          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes",
+          :method => :post,
+          :body => options[:body] || {}
+        })
+      end
+
       # @return a struct (or array of structs) that represents the search results by episode
       # @note If an organizationId wasn't given in options and there is an organization_id in config,
       #   it merges the organization_id from config into the params object that will be passed into MegaphoneClient#connection

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -32,7 +32,7 @@ module MegaphoneClient
 
       def create options={}
         if !options[:podcast_id] || !options[:body] || !options[:body][:title] || !options[:body][:pubdate]
-          raise MegaphoneClient::ClientError.new("podcast_id, body.title, and body.pubdate options are required.")
+          raise ArgumentError.new("podcast_id, body.title, and body.pubdate options are required.")
         end
 
         MegaphoneClient.connection({
@@ -79,7 +79,7 @@ module MegaphoneClient
 
       def update options={}
         if !options[:podcast_id] || !options[:episode_id]
-          raise MegaphoneClient::ClientError.new("Both podcast_id and episode_id options are required.")
+          raise ArgumentError.new("Both podcast_id and episode_id options are required.")
         end
 
         MegaphoneClient.connection({

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -21,7 +21,7 @@ module MegaphoneClient
       # @note If a :podcast_id, :body[:title], and :body[:pubdate] aren't given, it raises an error.
       # @see MegaphoneClient#connection
       # @example Create an episode
-      #   megaphone.episode.create({
+      #   megaphone.episodes.create({
       #     podcast_id: '12345',
       #     body: {
       #       title: "title",

--- a/megaphone_client.gemspec
+++ b/megaphone_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'megaphone_client'
-  s.version     = '0.1.0'
+  s.version     = '0.2.0'
   s.date        = '2018-03-13'
   s.summary     = "Ruby client for the Megaphone API"
   s.description = "Ruby client for the Megaphone API"

--- a/spec/fixtures/vcr_cassettes/create_result_01.yml
+++ b/spec/fixtures/vcr_cassettes/create_result_01.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes
+    body:
+      encoding: UTF-8
+      string: "{\"title\":\"This is a test title\",\"pubdate\":\"2020-06-01T14:54:02.690Z\"}"
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (darwin16.4.0 x86_64) ruby/2.1.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Token token=STUB_TOKEN
+      Params:
+      - ''
+      Content-Length:
+      - '69'
+      Host:
+      - cms.megaphone.fm
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Fri, 04 May 2018 17:24:17 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Token realm="Application"
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 7b82f50b-384a-41c8-a541-f7a75bb45bff
+      X-Runtime:
+      - '0.005025'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version:
+  recorded_at: Fri, 04 May 2018 17:24:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -4,6 +4,55 @@ require 'spec_helper'
 require 'webmock/rspec'
 
 describe MegaphoneClient::Episode do
+  describe "create" do
+    request_uri = "https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes"
+
+    before :each do
+      @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
+      @episodes = @megaphone.episodes
+    end
+
+    it "should return a MegaphoneClient::ConnectionError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
+      expect { @megaphone.episodes.create }.to raise_error(MegaphoneClient::ConnectionError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(MegaphoneClient::ConnectionError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(MegaphoneClient::ConnectionError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(MegaphoneClient::ConnectionError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(MegaphoneClient::ConnectionError)
+    end
+
+    it "should pass options[:body] as the body of the request" do
+      VCR.use_cassette("create_result_01") do
+        @megaphone.episodes.create({
+          podcast_id: "STUB_PODCAST_ID",
+          body: {
+            title: "This is a test title",
+            pubdate: "2020-06-01T14:54:02.690Z"
+          }
+        })
+
+        expect(WebMock).to have_requested(:post, request_uri)
+          .with(body: "{\"title\":\"This is a test title\",\"pubdate\":\"2020-06-01T14:54:02.690Z\"}")
+      end
+    end
+
+    it "should only perform POST requests" do
+      VCR.use_cassette("create_result_01") do
+        @megaphone.episodes.create({
+          podcast_id: "STUB_PODCAST_ID",
+          body: {
+            title: "This is a test title",
+            pubdate: "2020-06-01T14:54:02.690Z"
+          }
+        })
+
+        expect(WebMock).not_to have_requested(:get, request_uri)
+        expect(WebMock).not_to have_requested(:put, request_uri)
+        expect(WebMock).not_to have_requested(:patch, request_uri)
+        expect(WebMock).not_to have_requested(:delete, request_uri)
+      end
+    end
+  end
+
   describe "search" do
     before :each do
       @megaphone = MegaphoneClient.new({ organization_id: "STUB_ORGANIZATION_ID" })
@@ -46,7 +95,7 @@ describe MegaphoneClient::Episode do
       @episodes = @megaphone.episodes
     end
 
-    it "should return a an MegaphoneClient::ConnectionError if no podcast_id or episode_id is given" do
+    it "should return a MegaphoneClient::ConnectionError if no podcast_id or episode_id is given" do
       expect { @megaphone.episodes.update }.to raise_error(MegaphoneClient::ConnectionError)
     end
 

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -12,12 +12,12 @@ describe MegaphoneClient::Episode do
       @episodes = @megaphone.episodes
     end
 
-    it "should return a MegaphoneClient::ClientError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
-      expect { @megaphone.episodes.create }.to raise_error(MegaphoneClient::ClientError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(MegaphoneClient::ClientError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(MegaphoneClient::ClientError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(MegaphoneClient::ClientError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(MegaphoneClient::ClientError)
+    it "should return an ArgumentError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
+      expect { @megaphone.episodes.create }.to raise_error(ArgumentError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(ArgumentError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(ArgumentError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(ArgumentError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(ArgumentError)
     end
 
     it "should pass options[:body] as the body of the request" do
@@ -95,8 +95,8 @@ describe MegaphoneClient::Episode do
       @episodes = @megaphone.episodes
     end
 
-    it "should return a MegaphoneClient::ClientError if no podcast_id or episode_id is given" do
-      expect { @megaphone.episodes.update }.to raise_error(MegaphoneClient::ClientError)
+    it "should return an ArgumentError if no podcast_id or episode_id is given" do
+      expect { @megaphone.episodes.update }.to raise_error(ArgumentError)
     end
 
     it "should pass options[:body] as the body of the request" do

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -12,12 +12,12 @@ describe MegaphoneClient::Episode do
       @episodes = @megaphone.episodes
     end
 
-    it "should return a MegaphoneClient::ConnectionError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
-      expect { @megaphone.episodes.create }.to raise_error(MegaphoneClient::ConnectionError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(MegaphoneClient::ConnectionError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(MegaphoneClient::ConnectionError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(MegaphoneClient::ConnectionError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(MegaphoneClient::ConnectionError)
+    it "should return a MegaphoneClient::ClientError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
+      expect { @megaphone.episodes.create }.to raise_error(MegaphoneClient::ClientError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(MegaphoneClient::ClientError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(MegaphoneClient::ClientError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(MegaphoneClient::ClientError)
+      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(MegaphoneClient::ClientError)
     end
 
     it "should pass options[:body] as the body of the request" do
@@ -95,8 +95,8 @@ describe MegaphoneClient::Episode do
       @episodes = @megaphone.episodes
     end
 
-    it "should return a MegaphoneClient::ConnectionError if no podcast_id or episode_id is given" do
-      expect { @megaphone.episodes.update }.to raise_error(MegaphoneClient::ConnectionError)
+    it "should return a MegaphoneClient::ClientError if no podcast_id or episode_id is given" do
+      expect { @megaphone.episodes.update }.to raise_error(MegaphoneClient::ClientError)
     end
 
     it "should pass options[:body] as the body of the request" do


### PR DESCRIPTION
**The main file to look at is: `lib/megaphone_client/episode.rb`.**
I added a `create()` method that requires four different options:
- `podcast_id`
- `body`:
  - `title`
  - `pubdate`

If any of the above are missing, it throws a `MegaphoneClient::ConnectionError`.

**Testing**
- `spec/lib/megaphone_client/episode_spec.rb`
- Created a new vcr fixture to mock episode creation `POST`: `spec/fixtures/vcr_cassettes/create_result_01.yml`

**Example Use Case**
```ruby
megaphone.episodes.create({
  podcast_id: '{podcast_id}',
  body: {
    title: "{episode title}",
    pubdate: "2020-06-01T14:54:02.690Z"
  }
})
```
