### PR TITLE
Adds delete functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ megaphone.episodes.create({
 })
 ```
 
+### Deleting
+
+```ruby
+megaphone.episodes.delete({
+  podcast_id: '{podcast_id}',
+  episode_id: "{episode id}"
+})
+```
+
 ## Tests
 
 To run the tests:

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -42,6 +42,28 @@ module MegaphoneClient
         })
       end
 
+      # @return a struct with a message that the episode was successfully/unsuccessfully deleted
+      # @note If neither a :podcast_id and :episode_id are given, it raises an error
+      # @see MegaphoneClient#connection
+      # @example Delete an episode
+      #   megaphone.episode.delete({
+      #     podcast_id: '12345',
+      #     episode_id: '56789'
+      #   })
+      #   #=> A struct with a property "success" of type "string"
+
+      def delete options={}
+        if !options[:podcast_id] || !options[:episode_id]
+          raise ArgumentError.new("Both podcast_id and episode_id options are required.")
+        end
+
+        MegaphoneClient.connection({
+          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes/#{options[:episode_id]}",
+          :method => :delete,
+          :body => options[:body] || {}
+        })
+      end
+
       # @return a struct (or array of structs) that represents the search results by episode
       # @see MegaphoneClient#connection
       # @example Search for an episode with externalId 'show_episode-12345'

--- a/megaphone_client.gemspec
+++ b/megaphone_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'megaphone_client'
-  s.version     = '0.3.0'
+  s.version     = '0.4.0'
   s.date        = '2018-03-13'
   s.summary     = "Ruby client for the Megaphone API"
   s.description = "Ruby client for the Megaphone API"

--- a/spec/fixtures/vcr_cassettes/delete_result_01.yml
+++ b/spec/fixtures/vcr_cassettes/delete_result_01.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes/STUB_EPISODE_ID
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (darwin16.4.0 x86_64) ruby/2.1.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Token token=STUB_TOKEN
+      Params:
+      - ''
+      Content-Length:
+      - '2'
+      Host:
+      - cms.megaphone.fm
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 09 May 2018 22:18:27 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Token realm="Application"
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 674a25dd-2f74-4229-a15d-0de8d261b1de
+      X-Runtime:
+      - '0.007310'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version:
+  recorded_at: Wed, 09 May 2018 22:18:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -53,6 +53,34 @@ describe MegaphoneClient::Episode do
     end
   end
 
+  describe "delete" do
+    request_uri = "https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes/STUB_EPISODE_ID"
+
+    before :each do
+      @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
+      @episodes = @megaphone.episodes
+    end
+
+    it "should return an ArgumentError if no podcast_id or episode_id is given" do
+      expect { @megaphone.episodes.delete }.to raise_error(ArgumentError)
+    end
+
+    it "should only perform DELETE requests" do
+      VCR.use_cassette("delete_result_01") do
+        @megaphone.episodes.delete({
+          podcast_id: "STUB_PODCAST_ID",
+          episode_id: "STUB_EPISODE_ID"
+        })
+
+        expect(WebMock).to have_requested(:delete, request_uri)
+        expect(WebMock).not_to have_requested(:get, request_uri)
+        expect(WebMock).not_to have_requested(:patch, request_uri)
+        expect(WebMock).not_to have_requested(:post, request_uri)
+        expect(WebMock).not_to have_requested(:put, request_uri)
+      end
+    end
+  end
+
   describe "search" do
     before :each do
       @megaphone = MegaphoneClient.new


### PR DESCRIPTION
**Changes:**

- Added a `delete` method to the Episode class
- It throws an `ArgumentError` if it doesn't have two required options, `podcast_id` and `episode_id`
- It returns a struct with a property "success" if successfully deleted.
- Bumps minor version from 0.3.0 to 0.4.0

Tests:
https://github.com/SCPR/megaphone_client/blob/d09e790f8d396d876ae870e62df5ee0662c3dafb/spec/lib/megaphone_client/episode_spec.rb#L56-L82
