### PR TITLE
Restructured API with additional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,88 +22,10 @@ megaphone = MegaphoneClient.new({
 })
 ```
 
-### Podcasts
+### Documentation
 
-#### Creating a podcast
-
-```ruby
-megaphone.podcasts.new({
-  title: "{episode title}",
-  pubdate: "2020-06-01T14:54:02.690Z"
-})
-```
-
-#### Retrieving a list of podcasts
-
-```ruby
-megaphone.podcasts
-```
-
-#### Retrieving a podcast
-
-```ruby
-megaphone.podcast("{podcast id}")
-```
-
-#### Updating a podcast
-
-**Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
-
-```ruby
-megaphone.podcast("{podcast id}").update({
-  title: "New Title"
-})
-```
-
-#### Deleting a podcast
-
-```ruby
-megaphone.podcast("{podcast id}").delete
-```
-
-### Episodes
-
-#### Searching
-
-**Note:** the property `externalId` is written in camelCase because it's expected by the Megaphone API
-
-```ruby
-megaphone.episodes.search({ externalId: obj_key })
-```
-
-#### Creating an episode
-
-```ruby
-megaphone.podcast("{podcast_id}").episodes.new({
-  title: "{episode title}",
-  pubdate: "2020-06-01T14:54:02.690Z"
-})
-```
-
-
-#### Retrieving an episode
-
-```ruby
-megaphone.podcast("{podcast id}").episode("{episode id}")
-```
-
-#### Updating an episode
-
-**Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
-
-```ruby
-megaphone.podcast("{podcast id}").episode("{episode id}").update({
-  preCount: 1,
-  postCount: 2,
-  insertionPoints: ["10.1", "15.23", "18"]
-})
-```
-
-#### Deleting an episode
-
-```ruby
-megaphone.podcast("{podcast id}").episode("{episode id}").delete
-```
+You can view MegaphoneClient's documentation in RDoc format here:
+http://www.rubydoc.info/github/SCPR/megaphone_client/master/
 
 ## Tests
 
@@ -111,11 +33,6 @@ megaphone.podcast("{podcast id}").episode("{episode id}").delete
 ```bash
 bundle exec rspec spec
 ```
-
-## Documentation
-
-You can view MegaphoneClient's documentation in RDoc format here:
-http://www.rubydoc.info/github/SCPR/megaphone_client/master/
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,47 +30,74 @@ megaphone = MegaphoneClient.new({
 megaphone.episodes.search({ externalId: obj_key })
 ```
 
-### Updating
-
-**Note:** the properties in `body` are written in camelCase because it's expected by the Megaphone API
+### Listing podcasts
 
 ```ruby
-megaphone.episodes.update({
-  podcast_id: "{podcast id}",
-  episode_id: "{episode id}",
-  body: {
-    preCount: 1,
-    postCount: 2,
-    insertionPoints: ["10.1", "15.23", "18"]
-  }
+megaphone.podcasts
+```
+
+### Creating a podcast
+
+```ruby
+megaphone.podcasts.create({
+  title: "{episode title}",
+  pubdate: "2020-06-01T14:54:02.690Z"
 })
 ```
 
-### Listing Podcasts
+### Creating an episode
 
 ```ruby
-megaphone.podcasts.list
-```
-
-### Creating
-
-```ruby
-megaphone.episodes.create({
-  podcast_id: '{podcast_id}',
-  body: {
-    title: "{episode title}",
-    pubdate: "2020-06-01T14:54:02.690Z"
-  }
+megaphone.podcast("{podcast_id}").episodes.create({
+  title: "{episode title}",
+  pubdate: "2020-06-01T14:54:02.690Z"
 })
 ```
 
-### Deleting
+### Getting a podcast
 
 ```ruby
-megaphone.episodes.delete({
-  podcast_id: '{podcast_id}',
-  episode_id: "{episode id}"
+megaphone.podcast("{podcast id}")
+```
+
+### Getting an episode
+
+```ruby
+megaphone.podcast("{podcast id}").episode("{episode id}")
+```
+
+### Updating a podcast
+
+**Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
+
+```ruby
+megaphone.podcast("{podcast id}").update({
+  title: "New Title"
 })
+```
+
+### Updating an episode
+
+**Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
+
+```ruby
+megaphone.podcast("{podcast id}").episode("{episode id}").update({
+  preCount: 1,
+  postCount: 2,
+  insertionPoints: ["10.1", "15.23", "18"]
+})
+```
+
+### Deleting a podcast
+
+```ruby
+megaphone.podcast("{podcast id}").delete
+```
+
+### Deleting an episode
+
+```ruby
+megaphone.podcast("{podcast id}").episode("{episode id}").delete
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ megaphone.episodes.create({
 })
 ```
 
+### Deleting
+
+```ruby
+megaphone.episodes.delete({
+  podcast_id: '{podcast_id}',
+  episode_id: "{episode id}"
+})
+```
+
 ## Tests
 
 To run the tests:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://circleci.com/gh/SCPR/megaphone_client.png)](https://circleci.com/gh/SCPR/megaphone_client)
 
 # Megaphone Client
-Unofficial Ruby client for the Megaphone API
+An unofficial Ruby client for the Megaphone API
 
 ## Installation
 ```bash
@@ -12,7 +12,7 @@ gem 'megaphone_client', github:"scpr/megaphone_client"
 **Note:** Megaphone API props, such as `externalId`, are in camelCase instead of snake_case because Megaphone's API expects it when accessing their API. So when passing params or putting/posting a hash, use camelCase. When interfacing with the gem's API, use snake_case.
 
 ### Configuration
-Configure your app to connect to Megaphone, either in an initializer or your environment files:
+Configure your app to connect to Megaphone, either in an initializer or from your environment files:
 
 ```ruby
 megaphone = MegaphoneClient.new({
@@ -22,51 +22,30 @@ megaphone = MegaphoneClient.new({
 })
 ```
 
-### Searching
+### Podcasts
 
-**Note:** the property `externalId` is written in camelCase because it's expected by the Megaphone API
+#### Creating a podcast
 
 ```ruby
-megaphone.episodes.search({ externalId: obj_key })
+megaphone.podcasts.new({
+  title: "{episode title}",
+  pubdate: "2020-06-01T14:54:02.690Z"
+})
 ```
 
-### Listing podcasts
+#### Retrieving a list of podcasts
 
 ```ruby
 megaphone.podcasts
 ```
 
-### Creating a podcast
-
-```ruby
-megaphone.podcasts.create({
-  title: "{episode title}",
-  pubdate: "2020-06-01T14:54:02.690Z"
-})
-```
-
-### Creating an episode
-
-```ruby
-megaphone.podcast("{podcast_id}").episodes.create({
-  title: "{episode title}",
-  pubdate: "2020-06-01T14:54:02.690Z"
-})
-```
-
-### Getting a podcast
+#### Retrieving a podcast
 
 ```ruby
 megaphone.podcast("{podcast id}")
 ```
 
-### Getting an episode
-
-```ruby
-megaphone.podcast("{podcast id}").episode("{episode id}")
-```
-
-### Updating a podcast
+#### Updating a podcast
 
 **Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
 
@@ -76,7 +55,39 @@ megaphone.podcast("{podcast id}").update({
 })
 ```
 
-### Updating an episode
+#### Deleting a podcast
+
+```ruby
+megaphone.podcast("{podcast id}").delete
+```
+
+### Episodes
+
+#### Searching
+
+**Note:** the property `externalId` is written in camelCase because it's expected by the Megaphone API
+
+```ruby
+megaphone.episodes.search({ externalId: obj_key })
+```
+
+#### Creating an episode
+
+```ruby
+megaphone.podcast("{podcast_id}").episodes.new({
+  title: "{episode title}",
+  pubdate: "2020-06-01T14:54:02.690Z"
+})
+```
+
+
+#### Retrieving an episode
+
+```ruby
+megaphone.podcast("{podcast id}").episode("{episode id}")
+```
+
+#### Updating an episode
 
 **Note:** the properties in `update` are written in camelCase because it's expected by the Megaphone API
 
@@ -88,13 +99,7 @@ megaphone.podcast("{podcast id}").episode("{episode id}").update({
 })
 ```
 
-### Deleting a podcast
-
-```ruby
-megaphone.podcast("{podcast id}").delete
-```
-
-### Deleting an episode
+#### Deleting an episode
 
 ```ruby
 megaphone.podcast("{podcast id}").episode("{episode id}").delete
@@ -102,7 +107,7 @@ megaphone.podcast("{podcast id}").episode("{episode id}").delete
 
 ## Tests
 
-To run the tests:
+#### To run the tests:
 ```bash
 bundle exec rspec spec
 ```

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -39,7 +39,7 @@ module MegaphoneClient
     # @option options [String] :url Request url
     # @note This is a generalized REST method that is used by both the Episode and Podcast class.
     #   If it's successful, it returns a struct representing the data. If it fails, it raises a ConnectionError.
-    # @example Get a list of podcasts
+    # @example Get a list of podcasts with #connection
     #   megaphone.connection({
     #     method: :get,
     #     url: "https://cms.megaphone.fm/api/podcasts"
@@ -81,25 +81,15 @@ module MegaphoneClient
     end
 
     # @return a new instance of MegaphoneClient::EpisodeCollection
-    # @example Initialize MegaphoneClient into an instance, and then make a new Episodes instance
-    #   megaphone = MegaphoneClient.new({
-    #     network_id: '1234',
-    #     organization_id: '5678',
-    #     token: '910'
-    #   })
-    #   megaphone.episodes #=> new MegaphoneClient::Episode
+    # @example Make a new Episodes instance
+    #   megaphone.episodes #=> new MegaphoneClient::EpisodeCollection
 
     def episodes
       self::EpisodeCollection.new
     end
 
     # @return a new instance of MegaphoneClient::Podcast
-    # @example Initialize MegaphoneClient into an instance, and then make a new Podcast instance
-    #   megaphone = MegaphoneClient.new({
-    #     network_id: '1234',
-    #     organization_id: '5678',
-    #     token: '910'
-    #   })
+    # @example Make a new Podcast instance
     #   megaphone.podcast("12345") #=> new MegaphoneClient::Podcast with id 12345
 
     def podcast(id=nil)
@@ -107,13 +97,8 @@ module MegaphoneClient
     end
 
     # @return a new instance of MegaphoneCilent::PodcastCollection
-    # @example Initialize MegaphoneClient into an instance, and then make a new Podcasts instance
-    #   megaphone = MegaphoneClient.new({
-    #     network_id: '1234',
-    #     organization_id: '5678',
-    #     token: '910'
-    #   })
-    #   megaphone.podcasts #=> new MegaphoneClient::Podcast
+    # @example Make a new Podcasts instance
+    #   megaphone.podcasts #=> new MegaphoneClient::PodcastCollection
 
     def podcasts
       self::PodcastCollection.new

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -1,5 +1,7 @@
-require "megaphone_client/podcast"
+require "megaphone_client/episode_collection"
 require "megaphone_client/episode"
+require "megaphone_client/podcast_collection"
+require "megaphone_client/podcast"
 
 # @author Jay Arella
 module MegaphoneClient
@@ -78,8 +80,8 @@ module MegaphoneClient
       }
     end
 
-    # @return a new instance of MegaphoneClient::Episode
-    # @example Initialize MegaphoneClient into an instance
+    # @return a new instance of MegaphoneClient::EpisodeCollection
+    # @example Initialize MegaphoneClient into an instance, and then make a new Episodes instance
     #   megaphone = MegaphoneClient.new({
     #     network_id: '1234',
     #     organization_id: '5678',
@@ -88,24 +90,11 @@ module MegaphoneClient
     #   megaphone.episodes #=> new MegaphoneClient::Episode
 
     def episodes
-      self::Episode.new
+      self::EpisodeCollection.new
     end
 
     # @return a new instance of MegaphoneClient::Podcast
-    # @example Initialize MegaphoneClient into an instance
-    #   megaphone = MegaphoneClient.new({
-    #     network_id: '1234',
-    #     organization_id: '5678',
-    #     token: '910'
-    #   })
-    #   megaphone.podcasts #=> new MegaphoneClient::Podcast
-
-    def podcasts
-      self::Podcast.new
-    end
-
-    # @return a new instance of MegaphoneClient::Podcast
-    # @example Initialize MegaphoneClient into an instance
+    # @example Initialize MegaphoneClient into an instance, and then make a new Podcast instance
     #   megaphone = MegaphoneClient.new({
     #     network_id: '1234',
     #     organization_id: '5678',
@@ -115,6 +104,19 @@ module MegaphoneClient
 
     def podcast(id=nil)
       self::Podcast.new(id)
+    end
+
+    # @return a new instance of MegaphoneCilent::PodcastCollection
+    # @example Initialize MegaphoneClient into an instance, and then make a new Podcasts instance
+    #   megaphone = MegaphoneClient.new({
+    #     network_id: '1234',
+    #     organization_id: '5678',
+    #     token: '910'
+    #   })
+    #   megaphone.podcasts #=> new MegaphoneClient::Podcast
+
+    def podcasts
+      self::PodcastCollection.new
     end
   end
 end

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -101,7 +101,7 @@ module MegaphoneClient
     #   megaphone.episodes #=> new MegaphoneClient::Podcast
 
     def podcasts
-      self::Podcast.new.list
+      self::Podcast.new
     end
 
     def podcast(id=nil)

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -88,7 +88,7 @@ module MegaphoneClient
     #   megaphone.episodes #=> new MegaphoneClient::Episode
 
     def episodes
-      self::Episode
+      self::Episode.new
     end
 
     # @return a new instance of MegaphoneClient::Podcast
@@ -101,7 +101,11 @@ module MegaphoneClient
     #   megaphone.episodes #=> new MegaphoneClient::Podcast
 
     def podcasts
-      self::Podcast
+      self::Podcast.new.list
+    end
+
+    def podcast(id=nil)
+      self::Podcast.new(id)
     end
   end
 end

--- a/lib/megaphone_client.rb
+++ b/lib/megaphone_client.rb
@@ -98,11 +98,20 @@ module MegaphoneClient
     #     organization_id: '5678',
     #     token: '910'
     #   })
-    #   megaphone.episodes #=> new MegaphoneClient::Podcast
+    #   megaphone.podcasts #=> new MegaphoneClient::Podcast
 
     def podcasts
       self::Podcast.new
     end
+
+    # @return a new instance of MegaphoneClient::Podcast
+    # @example Initialize MegaphoneClient into an instance
+    #   megaphone = MegaphoneClient.new({
+    #     network_id: '1234',
+    #     organization_id: '5678',
+    #     token: '910'
+    #   })
+    #   megaphone.podcast("12345") #=> new MegaphoneClient::Podcast with id 12345
 
     def podcast(id=nil)
       self::Podcast.new(id)

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -6,102 +6,125 @@ module MegaphoneClient
 
   # @author Jay Arella
   class Episode
-    class << self
+    def initialize(podcast_id=nil, id=nil)
+      @id = id
+      @podcast_id = podcast_id
+    end
 
-      # @return a MegaphoneClient
-      # @note This is used as a way to access top level attributes
-      # @example Accessing a network id
-      #   config.network_id #=> '{network id specified in initialization}'
+    # @return a MegaphoneClient
+    # @note This is used as a way to access top level attributes
+    # @example Accessing a network id
+    #   config.network_id #=> '{network id specified in initialization}'
 
-      def config
-        @config ||= MegaphoneClient
+    def config
+      @config ||= MegaphoneClient
+    end
+
+    # @return a struct that represents the episode that was created
+    # @note If a @podcast_id, :body[:title], and :body[:pubdate] aren't given, it raises an error.
+    # @see MegaphoneClient#connection
+    # @example Create an episode
+    #   megaphone.episodes.create({
+    #     podcast_id: '12345',
+    #     body: {
+    #       title: "title",
+    #       pubdate: "2020-06-01T14:54:02.690Z"
+    #     }
+    #   })
+    #   #=> A struct representing episode '12345' with title, "title", and scheduled to publish at June 1st, 2020
+
+    def create options={}
+      if !@podcast_id || !options || !options[:title] || !options[:pubdate]
+        raise ArgumentError.new("@podcast_id, options[:title], and options[:pubdate] variables are required.")
       end
 
-      # @return a struct that represents the episode that was created
-      # @note If a :podcast_id, :body[:title], and :body[:pubdate] aren't given, it raises an error.
-      # @see MegaphoneClient#connection
-      # @example Create an episode
-      #   megaphone.episodes.create({
-      #     podcast_id: '12345',
-      #     body: {
-      #       title: "title",
-      #       pubdate: "2020-06-01T14:54:02.690Z"
-      #     }
-      #   })
-      #   #=> A struct representing episode '12345' with title, "title", and scheduled to publish at June 1st, 2020
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes",
+        :method => :post,
+        :body => options
+      })
+    end
 
-      def create options={}
-        if !options[:podcast_id] || !options[:body] || !options[:body][:title] || !options[:body][:pubdate]
-          raise ArgumentError.new("podcast_id, body.title, and body.pubdate options are required.")
-        end
+    # @return a struct with a message that the episode was successfully/unsuccessfully deleted
+    # @note If neither a @podcast_id and @episode_id are given, it raises an error
+    # @see MegaphoneClient#connection
+    # @example Delete an episode
+    #   megaphone.episode.delete({
+    #     podcast_id: '12345',
+    #     episode_id: '56789'
+    #   })
+    #   #=> A struct with a property "success" of type "string"
 
-        MegaphoneClient.connection({
-          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes",
-          :method => :post,
-          :body => options[:body] || {}
-        })
+    def delete options={}
+      if !@podcast_id || !@id
+        raise ArgumentError.new("Both @podcast_id and @id variables are required.")
       end
 
-      # @return a struct with a message that the episode was successfully/unsuccessfully deleted
-      # @note If neither a :podcast_id and :episode_id are given, it raises an error
-      # @see MegaphoneClient#connection
-      # @example Delete an episode
-      #   megaphone.episode.delete({
-      #     podcast_id: '12345',
-      #     episode_id: '56789'
-      #   })
-      #   #=> A struct with a property "success" of type "string"
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes/#{@id}",
+        :method => :delete
+      })
+    end
 
-      def delete options={}
-        if !options[:podcast_id] || !options[:episode_id]
-          raise ArgumentError.new("Both podcast_id and episode_id options are required.")
-        end
-
-        MegaphoneClient.connection({
-          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes/#{options[:episode_id]}",
-          :method => :delete,
-          :body => options[:body] || {}
-        })
+    def list options={}
+      if !@podcast_id
+        raise ArgumentError.new("The @podcast_id variable is required.")
       end
 
-      # @return a struct (or array of structs) that represents the search results by episode
-      # @see MegaphoneClient#connection
-      # @example Search for an episode with externalId 'show_episode-12345'
-      #   megaphone.episode.search({
-      #     externalId: 'show_episode-1245'
-      #   })
-      #   #=> A struct representing 'show_episode-12345'
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes",
+        :method => :get
+      })
+    end
 
-      def search params={}
-        MegaphoneClient.connection({
-          :url => "#{config.api_base_url}/search/episodes",
-          :method => :get,
-          :params => params
-        })
+    def show options={}
+      if !@podcast_id || !@id
+        raise ArgumentError.new("Both @podcast_id and @id variables are required.")
       end
 
-      # @return a struct that represents the episode that was updated
-      # @note If neither a :podcast_id and :episode_id are given, it raises an error
-      # @see MegaphoneClient#connection
-      # @example Update an episode's preCount
-      #   megaphone.episode.update({
-      #     podcast_id: '12345',
-      #     episode_id: '56789',
-      #     body: { preCount: 2 }
-      #   })
-      #   #=> A struct representing episode '56789' with preCount 2
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes/#{@id}",
+        :method => :get
+      })
+    end
 
-      def update options={}
-        if !options[:podcast_id] || !options[:episode_id]
-          raise ArgumentError.new("Both podcast_id and episode_id options are required.")
-        end
+    # @return a struct (or array of structs) that represents the search results by episode
+    # @see MegaphoneClient#connection
+    # @example Search for an episode with externalId 'show_episode-12345'
+    #   megaphone.episode.search({
+    #     externalId: 'show_episode-1245'
+    #   })
+    #   #=> A struct representing 'show_episode-12345'
 
-        MegaphoneClient.connection({
-          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes/#{options[:episode_id]}",
-          :method => :put,
-          :body => options[:body] || {}
-        })
+    def search params={}
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/search/episodes",
+        :method => :get,
+        :params => params
+      })
+    end
+
+    # @return a struct that represents the episode that was updated
+    # @note If neither a @podcast_id and @episode_id are given, it raises an error
+    # @see MegaphoneClient#connection
+    # @example Update an episode's preCount
+    #   megaphone.episode.update({
+    #     podcast_id: '12345',
+    #     episode_id: '56789',
+    #     body: { preCount: 2 }
+    #   })
+    #   #=> A struct representing episode '56789' with preCount 2
+
+    def update options={}
+      if !@podcast_id || !@id
+        raise ArgumentError.new("Both @podcast_id and @id variables are required.")
       end
+
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes/#{@id}",
+        :method => :put,
+        :body => options
+      })
     end
   end
 end

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -7,7 +7,7 @@ module MegaphoneClient
   # @author Jay Arella
   class Episode
 
-    # @return a MegaphoneClient instance
+    # @return a MegaphoneClient::Episode instance
     # @note This is used to initialize the podcast id and episode id when creating a new Episode instance
     # @example Create a new instance of MegaphoneClient::Episode
     #   MegaphoneClient::Episode.new("{podcast_id}", "{episode_id}") #=> #<MegaphoneClient::Episode @id="{episode_id}", @podcast_id="{podcast_id}">
@@ -87,7 +87,7 @@ module MegaphoneClient
     # @return a struct that represents an episode of a given podcast id and episode id
     # @see MegaphoneClient#connection
     # @example Show an episode
-    #   megaphone.podcast("12345").episode("56789").delete
+    #   megaphone.podcast("12345").episode("56789").show
     #   #=> A struct representing episode 56789
 
     def show options={}

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -6,6 +6,12 @@ module MegaphoneClient
 
   # @author Jay Arella
   class Episode
+
+    # @return a MegaphoneClient instance
+    # @note This is used to initialize the podcast id and episode id when creating a new Episode instance
+    # @example Create a new instance of MegaphoneClient::Episode
+    #   MegaphoneClient::Episode.new("{podcast_id}", "{episode_id}") #=> #<MegaphoneClient::Episode @id="{episode_id}", @podcast_id="{podcast_id}">
+
     def initialize(podcast_id=nil, id=nil)
       @id = id
       @podcast_id = podcast_id
@@ -21,15 +27,12 @@ module MegaphoneClient
     end
 
     # @return a struct that represents the episode that was created
-    # @note If a @podcast_id, :body[:title], and :body[:pubdate] aren't given, it raises an error.
+    # @note If a @podcast_id, options[:title], and options[:pubdate] aren't given, it raises an error.
     # @see MegaphoneClient#connection
     # @example Create an episode
-    #   megaphone.episodes.create({
-    #     podcast_id: '12345',
-    #     body: {
-    #       title: "title",
-    #       pubdate: "2020-06-01T14:54:02.690Z"
-    #     }
+    #   megaphone.podcast("12345").episode.create({
+    #     title: "title",
+    #     pubdate: "2020-06-01T14:54:02.690Z"
     #   })
     #   #=> A struct representing episode '12345' with title, "title", and scheduled to publish at June 1st, 2020
 
@@ -49,10 +52,7 @@ module MegaphoneClient
     # @note If neither a @podcast_id and @episode_id are given, it raises an error
     # @see MegaphoneClient#connection
     # @example Delete an episode
-    #   megaphone.episode.delete({
-    #     podcast_id: '12345',
-    #     episode_id: '56789'
-    #   })
+    #   megaphone.podcast("12345").episode("56789").delete
     #   #=> A struct with a property "success" of type "string"
 
     def delete options={}
@@ -66,6 +66,13 @@ module MegaphoneClient
       })
     end
 
+    # @return an array of structs that represent a list of episodes for a given podcast
+    # @note If a @podcast_id is not given, it raises an error
+    # @see MegaphoneClient#connection
+    # @example List a podcast's episodes
+    #   megaphone.podcast("12345").episodes.list
+    #   #=> An array of structs representing a list of episodes for a given podcast
+
     def list options={}
       if !@podcast_id
         raise ArgumentError.new("The @podcast_id variable is required.")
@@ -76,6 +83,12 @@ module MegaphoneClient
         :method => :get
       })
     end
+
+    # @return a struct that represents an episode of a given podcast id and episode id
+    # @see MegaphoneClient#connection
+    # @example Show an episode
+    #   megaphone.podcast("12345").episode("56789").delete
+    #   #=> A struct representing episode 56789
 
     def show options={}
       if !@podcast_id || !@id
@@ -88,13 +101,13 @@ module MegaphoneClient
       })
     end
 
-    # @return a struct (or array of structs) that represents the search results by episode
+    # @return an array of structs that represents the search results by episode
     # @see MegaphoneClient#connection
     # @example Search for an episode with externalId 'show_episode-12345'
     #   megaphone.episode.search({
     #     externalId: 'show_episode-1245'
     #   })
-    #   #=> A struct representing 'show_episode-12345'
+    #   #=> An array of one struct representing 'show_episode-12345'
 
     def search params={}
       MegaphoneClient.connection({
@@ -108,10 +121,8 @@ module MegaphoneClient
     # @note If neither a @podcast_id and @episode_id are given, it raises an error
     # @see MegaphoneClient#connection
     # @example Update an episode's preCount
-    #   megaphone.episode.update({
-    #     podcast_id: '12345',
-    #     episode_id: '56789',
-    #     body: { preCount: 2 }
+    #   megaphone.podcast("12345").episode("56789").update({
+    #     preCount: 2
     #   })
     #   #=> A struct representing episode '56789' with preCount 2
 

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -9,7 +9,7 @@ module MegaphoneClient
 
     # @return a MegaphoneClient::Episode instance
     # @note This is used to initialize the podcast id and episode id when creating a new Episode instance
-    # @example Create a new instance of MegaphoneClient::Episode
+    # @example Initialize a new instance of MegaphoneClient::Episode
     #   MegaphoneClient::Episode.new("{podcast_id}", "{episode_id}") #=> #<MegaphoneClient::Episode @id="{episode_id}", @podcast_id="{podcast_id}">
 
     def initialize(podcast_id=nil, id=nil)
@@ -19,7 +19,7 @@ module MegaphoneClient
 
     # @return a MegaphoneClient
     # @note This is used as a way to access top level attributes
-    # @example Accessing a network id
+    # @example Accessing a network id configuration
     #   config.network_id #=> '{network id specified in initialization}'
 
     def config
@@ -66,24 +66,6 @@ module MegaphoneClient
       })
     end
 
-    # @return an array of structs that represent a list of episodes for a given podcast
-    # @note If a @podcast_id is not given, it raises an error
-    # @see MegaphoneClient#connection
-    # @example List a podcast's episodes
-    #   megaphone.podcast("12345").episodes.list
-    #   #=> An array of structs representing a list of episodes for a given podcast
-
-    def list options={}
-      if !@podcast_id
-        raise ArgumentError.new("The @podcast_id variable is required.")
-      end
-
-      MegaphoneClient.connection({
-        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes",
-        :method => :get
-      })
-    end
-
     # @return a struct that represents an episode of a given podcast id and episode id
     # @see MegaphoneClient#connection
     # @example Show an episode
@@ -98,22 +80,6 @@ module MegaphoneClient
       MegaphoneClient.connection({
         :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes/#{@id}",
         :method => :get
-      })
-    end
-
-    # @return an array of structs that represents the search results by episode
-    # @see MegaphoneClient#connection
-    # @example Search for an episode with externalId 'show_episode-12345'
-    #   megaphone.episode.search({
-    #     externalId: 'show_episode-1245'
-    #   })
-    #   #=> An array of one struct representing 'show_episode-12345'
-
-    def search params={}
-      MegaphoneClient.connection({
-        :url => "#{config.api_base_url}/search/episodes",
-        :method => :get,
-        :params => params
       })
     end
 

--- a/lib/megaphone_client/episode.rb
+++ b/lib/megaphone_client/episode.rb
@@ -42,6 +42,28 @@ module MegaphoneClient
         })
       end
 
+      # @return a struct with a message that the episode was successfully/unsuccessfully deleted
+      # @note If neither a :podcast_id and :episode_id are given, it raises an error
+      # @see MegaphoneClient#connection
+      # @example Delete an episode
+      #   megaphone.episode.delete({
+      #     podcast_id: '12345',
+      #     episode_id: '56789'
+      #   })
+      #   #=> A struct with a property "success" of type "string"
+
+      def delete options={}
+        if !options[:podcast_id] || !options[:episode_id]
+          raise ArgumentError.new("Both podcast_id and episode_id options are required.")
+        end
+
+        MegaphoneClient.connection({
+          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{options[:podcast_id]}/episodes/#{options[:episode_id]}",
+          :method => :delete,
+          :body => options[:body] || {}
+        })
+      end
+
       # @return a struct (or array of structs) that represents the search results by episode
       # @see MegaphoneClient#connection
       # @example Search for an episode with externalId 'show_episode-12345'

--- a/lib/megaphone_client/episode_collection.rb
+++ b/lib/megaphone_client/episode_collection.rb
@@ -1,0 +1,62 @@
+require "ostruct"
+require "json"
+require "rest-client"
+
+module MegaphoneClient
+
+  # @author Jay Arella
+  class EpisodeCollection
+
+    # @return a MegaphoneClient::EpisodeCollection instance
+    # @note This is used to initialize the podcast id and episode id when creating a new Episode instance
+    # @example Initialize a new instance of MegaphoneClient::EpisodeCollection
+    #   MegaphoneClient::EpisodeCollection.new("{podcast_id}") #=> #<MegaphoneClient::EpisodeCollection @id=nil, @podcast_id="{podcast_id}">
+
+    def initialize(podcast_id=nil)
+      @podcast_id = podcast_id
+    end
+
+    # @return a MegaphoneClient
+    # @note This is used as a way to access top level attributes
+    # @example Accessing a network id configuration
+    #   config.network_id #=> '{network id specified in initialization}'
+
+    def config
+      @config ||= MegaphoneClient
+    end
+
+    # @return an array of structs that represent a list of episodes for a given podcast
+    # @note If a @podcast_id is not given, it raises an error
+    # @see MegaphoneClient#connection
+    # @example List a podcast's episodes
+    #   megaphone.podcast("12345").episodes.list
+    #   #=> An array of structs representing a list of episodes for a given podcast
+
+    def list options={}
+      if !@podcast_id
+        raise ArgumentError.new("The @podcast_id variable is required.")
+      end
+
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@podcast_id}/episodes",
+        :method => :get
+      })
+    end
+
+    # @return an array of structs that represents the search results by episode
+    # @see MegaphoneClient#connection
+    # @example Search for an episode with externalId 'show_episode-12345'
+    #   megaphone.episode.search({
+    #     externalId: 'show_episode-1245'
+    #   })
+    #   #=> An array of one struct representing 'show_episode-12345'
+
+    def search params={}
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/search/episodes",
+        :method => :get,
+        :params => params
+      })
+    end
+  end
+end

--- a/lib/megaphone_client/podcast.rb
+++ b/lib/megaphone_client/podcast.rb
@@ -6,29 +6,49 @@ module MegaphoneClient
 
   # @author Jay Arella
   class Podcast
-    class << self
+    def initialize(id=nil)
+      @id = id
+    end
 
-      # @return a MegaphoneClient
-      # @note This is used as a way to access top level attributes
-      # @example Accessing a network id
-      #   config.network_id #=> '{network id specified in initialization}'
+    def episode(episode_id=nil)
+      MegaphoneClient::Episode.new(@id, episode_id)
+    end
 
-      def config
-        @config ||= MegaphoneClient
+    def episodes
+      MegaphoneClient::Episode.new(@id).list
+    end
+
+    # @return a MegaphoneClient
+    # @note This is used as a way to access top level attributes
+    # @example Accessing a network id
+    #   config.network_id #=> '{network id specified in initialization}'
+
+    def config
+      @config ||= MegaphoneClient
+    end
+
+    # @return an array of structs that represents a list of podcasts
+    # @note It needs to be initialized with a network id
+    # @see MegaphoneClient#connection
+    # @example Get a list of all podcasts
+    #   megaphone.podcasts.list #=> An array of structs representing a list of podcasts
+
+    def list options={}
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts",
+        :method => :get
+      })
+    end
+
+    def show options={}
+      if !@id
+        raise ArgumentError.new("The @id variable is required.")
       end
 
-      # @return an array of structs that represents a list of podcasts
-      # @note It needs to be initialized with a network id
-      # @see MegaphoneClient#connection
-      # @example Get a list of all podcasts
-      #   megaphone.podcasts.list #=> An array of structs representing a list of podcasts
-
-      def list options={}
-        MegaphoneClient.connection({
-          :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts",
-          :method => :get
-        })
-      end
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts/#{@id}",
+        :method => :get
+      })
     end
   end
 end

--- a/lib/megaphone_client/podcast.rb
+++ b/lib/megaphone_client/podcast.rb
@@ -6,16 +6,32 @@ module MegaphoneClient
 
   # @author Jay Arella
   class Podcast
+
+    # @return a MegaphoneClient::Podcast instance
+    # @note This is used to initialize the podcast id when creating a new Podcast instance
+    # @example Create a new instance of MegaphoneClient::Podcast
+    #   MegaphoneClient::Podcast.new("{podcast_id}") #=> #<MegaphoneClient::Podcast @id="{podcast_id}">
+
     def initialize(id=nil)
       @id = id
     end
+
+    # @return a MegaphoneClient::Episode instance
+    # @note This is used to call a new Episode instance with a given podcast id and episode_id
+    # @example Call a new instance of MegaphoneClient::Episode
+    #   megaphone.podcast("12345").episode("56789") #=> #<MegaphoneClient::Episode @id="{episode_Id}" @podcast_id="{podcast_id}" >
 
     def episode(episode_id=nil)
       MegaphoneClient::Episode.new(@id, episode_id)
     end
 
+    # @return a MegaphoneClient::Episode instance
+    # @note This is used to call a new Episode instance with a given podcast id
+    # @example Call a new instance of MegaphoneClient::Episode
+    #   megaphone.podcast("12345").episodes #=> #<MegaphoneClient::Episode @id=nil @podcast_id="{podcast_id}" >
+
     def episodes
-      MegaphoneClient::Episode.new(@id).list
+      MegaphoneClient::Episode.new(@id)
     end
 
     # @return a MegaphoneClient
@@ -39,6 +55,13 @@ module MegaphoneClient
         :method => :get
       })
     end
+
+    # @return a struct that represents a podcast of a given podcast id
+    # @note It needs to be initialized with an @id, otherwise it will return an ArgumentError
+    # @see MegaphoneClient#connection
+    # @example Show a podcast
+    #   megaphone.podcast("12345").show
+    #   #=> A struct representing podcast 12345
 
     def show options={}
       if !@id

--- a/lib/megaphone_client/podcast.rb
+++ b/lib/megaphone_client/podcast.rb
@@ -25,13 +25,13 @@ module MegaphoneClient
       MegaphoneClient::Episode.new(@id, episode_id)
     end
 
-    # @return a MegaphoneClient::Episode instance
-    # @note This is used to call a new Episode instance with a given podcast id
-    # @example Call a new instance of MegaphoneClient::Episode
-    #   megaphone.podcast("12345").episodes #=> #<MegaphoneClient::Episode @id=nil @podcast_id="{podcast_id}" >
+    # @return a MegaphoneClient::EpisodeCollection instance
+    # @note This is used to call a new Episodes instance with a given podcast id
+    # @example Call a new instance of MegaphoneClient::EpisodeCollection
+    #   megaphone.podcast("12345").episodes #=> #<MegaphoneClient::EpisodeCollection @podcast_id="{podcast_id}" >
 
     def episodes
-      MegaphoneClient::Episode.new(@id)
+      MegaphoneClient::EpisodeCollection.new(@id)
     end
 
     # @return a MegaphoneClient
@@ -41,19 +41,6 @@ module MegaphoneClient
 
     def config
       @config ||= MegaphoneClient
-    end
-
-    # @return an array of structs that represents a list of podcasts
-    # @note It needs to be initialized with a network id
-    # @see MegaphoneClient#connection
-    # @example Get a list of all podcasts
-    #   megaphone.podcasts.list #=> An array of structs representing a list of podcasts
-
-    def list options={}
-      MegaphoneClient.connection({
-        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts",
-        :method => :get
-      })
     end
 
     # @return a struct that represents a podcast of a given podcast id

--- a/lib/megaphone_client/podcast_collection.rb
+++ b/lib/megaphone_client/podcast_collection.rb
@@ -1,0 +1,32 @@
+require "ostruct"
+require "json"
+require "rest-client"
+
+module MegaphoneClient
+
+  # @author Jay Arella
+  class PodcastCollection
+
+    # @return a MegaphoneClient
+    # @note This is used as a way to access top level attributes
+    # @example Accessing a network id
+    #   config.network_id #=> '{network id specified in initialization}'
+
+    def config
+      @config ||= MegaphoneClient
+    end
+
+    # @return an array of structs that represents a list of podcasts
+    # @note It needs to be initialized with a network id
+    # @see MegaphoneClient#connection
+    # @example Get a list of all podcasts
+    #   megaphone.podcasts.list #=> An array of structs representing a list of podcasts
+
+    def list options={}
+      MegaphoneClient.connection({
+        :url => "#{config.api_base_url}/networks/#{config.network_id}/podcasts",
+        :method => :get
+      })
+    end
+  end
+end

--- a/megaphone_client.gemspec
+++ b/megaphone_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'megaphone_client'
-  s.version     = '0.4.0'
+  s.version     = '0.5.0'
   s.date        = '2018-03-13'
   s.summary     = "Ruby client for the Megaphone API"
   s.description = "Ruby client for the Megaphone API"

--- a/megaphone_client.gemspec
+++ b/megaphone_client.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'megaphone_client'
-  s.version     = '0.3.0'
+  s.version     = '0.4.0'
   s.date        = '2018-03-13'
   s.summary     = "Ruby client for the Megaphone API"
   s.description = "Ruby client for the Megaphone API"

--- a/spec/fixtures/vcr_cassettes/delete_result_01.yml
+++ b/spec/fixtures/vcr_cassettes/delete_result_01.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes/STUB_EPISODE_ID
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.1 (darwin16.4.0 x86_64) ruby/2.1.0p0
+      Content-Type:
+      - application/json
+      Authorization:
+      - Token token=STUB_TOKEN
+      Params:
+      - ''
+      Content-Length:
+      - '2'
+      Host:
+      - cms.megaphone.fm
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Cowboy
+      Date:
+      - Wed, 09 May 2018 22:18:27 GMT
+      Connection:
+      - keep-alive
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Www-Authenticate:
+      - Token realm="Application"
+      Content-Type:
+      - text/html; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 674a25dd-2f74-4229-a15d-0de8d261b1de
+      X-Runtime:
+      - '0.007310'
+      Transfer-Encoding:
+      - chunked
+      Via:
+      - 1.1 vegur
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version:
+  recorded_at: Wed, 09 May 2018 22:18:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -9,25 +9,25 @@ describe MegaphoneClient::Episode do
 
     before :each do
       @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
-      @episodes = @megaphone.episodes
+      @podcast = @megaphone.podcast('STUB_PODCAST_ID')
     end
 
     it "should return an ArgumentError if lacking any of the required options: podcast_id, body, body[:title], body[:pubdate]" do
-      expect { @megaphone.episodes.create }.to raise_error(ArgumentError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID" }) }.to raise_error(ArgumentError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: {} }) }.to raise_error(ArgumentError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { title: "example_title" } }) }.to raise_error(ArgumentError)
-      expect { @megaphone.episodes.create({ podcast_id: "STUB_PODCAST_ID", body: { pubdate: "2020-06-01T14:54:02.690Z" } }) }.to raise_error(ArgumentError)
+      podcast_without_id = @megaphone.podcast
+      podcast_with_id = @podcast
+
+      expect { podcast_without_id.episode.create }.to raise_error(ArgumentError)
+      expect { podcast_with_id.episode.create }.to raise_error(ArgumentError)
+      expect { podcast_with_id.episode.create({}) }.to raise_error(ArgumentError)
+      expect { podcast_with_id.episode.create({ title: "example_title" }) }.to raise_error(ArgumentError)
+      expect { podcast_with_id.episode.create({ pubdate: "2020-06-01T14:54:02.690Z" }) }.to raise_error(ArgumentError)
     end
 
     it "should pass options[:body] as the body of the request" do
       VCR.use_cassette("create_result_01") do
-        @megaphone.episodes.create({
-          podcast_id: "STUB_PODCAST_ID",
-          body: {
-            title: "This is a test title",
-            pubdate: "2020-06-01T14:54:02.690Z"
-          }
+        @podcast.episode.create({
+          title: "This is a test title",
+          pubdate: "2020-06-01T14:54:02.690Z"
         })
 
         expect(WebMock).to have_requested(:post, request_uri)
@@ -37,12 +37,9 @@ describe MegaphoneClient::Episode do
 
     it "should only perform POST requests" do
       VCR.use_cassette("create_result_01") do
-        @megaphone.episodes.create({
-          podcast_id: "STUB_PODCAST_ID",
-          body: {
-            title: "This is a test title",
-            pubdate: "2020-06-01T14:54:02.690Z"
-          }
+        @podcast.episode.create({
+          title: "This is a test title",
+          pubdate: "2020-06-01T14:54:02.690Z"
         })
 
         expect(WebMock).not_to have_requested(:get, request_uri)
@@ -58,19 +55,18 @@ describe MegaphoneClient::Episode do
 
     before :each do
       @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
-      @episodes = @megaphone.episodes
+      @podcast = @megaphone.podcast('STUB_PODCAST_ID')
     end
 
     it "should return an ArgumentError if no podcast_id or episode_id is given" do
-      expect { @megaphone.episodes.delete }.to raise_error(ArgumentError)
+      podcast_without_id = @megaphone.podcast
+
+      expect { podcast_without_id.episode.delete }.to raise_error(ArgumentError)
     end
 
     it "should only perform DELETE requests" do
       VCR.use_cassette("delete_result_01") do
-        @megaphone.episodes.delete({
-          podcast_id: "STUB_PODCAST_ID",
-          episode_id: "STUB_EPISODE_ID"
-        })
+        @podcast.episode("STUB_EPISODE_ID").delete
 
         expect(WebMock).to have_requested(:delete, request_uri)
         expect(WebMock).not_to have_requested(:get, request_uri)
@@ -105,23 +101,19 @@ describe MegaphoneClient::Episode do
 
     before :each do
       @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
-      @episodes = @megaphone.episodes
+      @podcast = @megaphone.podcast('STUB_PODCAST_ID')
     end
 
     it "should return an ArgumentError if no podcast_id or episode_id is given" do
-      expect { @megaphone.episodes.update }.to raise_error(ArgumentError)
+      expect { @podcast.episode.update }.to raise_error(ArgumentError)
     end
 
     it "should pass options[:body] as the body of the request" do
       VCR.use_cassette("update_result_01") do
-        @megaphone.episodes.update({
-          podcast_id: "STUB_PODCAST_ID",
-          episode_id: "STUB_EPISODE_ID",
-          body: {
-            preCount: 1,
-            postCount: 2,
-            insertionPoints: ["10.1", "15.23", "18"]
-          }
+        @podcast.episode("STUB_EPISODE_ID").update({
+          preCount: 1,
+          postCount: 2,
+          insertionPoints: ["10.1", "15.23", "18"]
         })
 
         expect(WebMock).to have_requested(:put, request_uri)
@@ -131,10 +123,7 @@ describe MegaphoneClient::Episode do
 
     it "should pass an empty body if not given in options" do
       VCR.use_cassette("update_result_02") do
-        @megaphone.episodes.update({
-          podcast_id: "STUB_PODCAST_ID",
-          episode_id: "STUB_EPISODE_ID"
-        })
+        @podcast.episode("STUB_EPISODE_ID").update
 
         expect(WebMock).to have_requested(:put, request_uri)
           .with(body: "{}")
@@ -143,10 +132,7 @@ describe MegaphoneClient::Episode do
 
     it "should only perform PUT requests" do
       VCR.use_cassette("update_result_01") do
-        @megaphone.episodes.update({
-          podcast_id: "STUB_PODCAST_ID",
-          episode_id: "STUB_EPISODE_ID"
-        })
+        @podcast.episode("STUB_EPISODE_ID").update
 
         expect(WebMock).not_to have_requested(:get, request_uri)
         expect(WebMock).not_to have_requested(:post, request_uri)

--- a/spec/lib/megaphone_client/episode_spec.rb
+++ b/spec/lib/megaphone_client/episode_spec.rb
@@ -53,6 +53,34 @@ describe MegaphoneClient::Episode do
     end
   end
 
+  describe "delete" do
+    request_uri = "https://cms.megaphone.fm/api/networks/STUB_NETWORK_ID/podcasts/STUB_PODCAST_ID/episodes/STUB_EPISODE_ID"
+
+    before :each do
+      @megaphone = MegaphoneClient.new({ network_id: "STUB_NETWORK_ID" })
+      @episodes = @megaphone.episodes
+    end
+
+    it "should return an ArgumentError if no podcast_id or episode_id is given" do
+      expect { @megaphone.episodes.delete }.to raise_error(ArgumentError)
+    end
+
+    it "should only perform DELETE requests" do
+      VCR.use_cassette("delete_result_01") do
+        @megaphone.episodes.delete({
+          podcast_id: "STUB_PODCAST_ID",
+          episode_id: "STUB_EPISODE_ID"
+        })
+
+        expect(WebMock).to have_requested(:delete, request_uri)
+        expect(WebMock).not_to have_requested(:get, request_uri)
+        expect(WebMock).not_to have_requested(:patch, request_uri)
+        expect(WebMock).not_to have_requested(:post, request_uri)
+        expect(WebMock).not_to have_requested(:put, request_uri)
+      end
+    end
+  end
+
   describe "search" do
     before :each do
       @megaphone = MegaphoneClient.new


### PR DESCRIPTION
## Major changes:

#### The gem's API now flows more naturally now in that you can chain commands like this:
```ruby
megaphone.podcast("12345").show # => podcast object
megaphone.podcast("12345").episode("56789").show # => episode object
```

#### Collections are abstracted to their own classes
```ruby
megaphone.podcasts.list # => array of podcast objects
megaphone.podcast("12345").episodes.list # => array of episode objects
megaphone.podcast("12345").list # => a nomethod error because we're calling a collection method from a singular
```

#### CRUD methods no longer need to be nested into a `body` property
```ruby
megaphone.podcast("12345").episode("56789").update({ title: "This is a new title" }) # => episode object
```

#### The gem exposes the methods to instances rather than the class itself, which allows for something like this
```ruby
podcast = megaphone.podcast("12345")
episode = podcast.episode("45678")
episode.delete
```

#### New methods were added
- `delete` for individual episodes
- `show` for individual episodes and podcasts